### PR TITLE
add air temperature

### DIFF
--- a/snotel.rb
+++ b/snotel.rb
@@ -102,6 +102,12 @@ class Snotel < Sinatra::Base
     # http://wcc.sc.egov.usda.gov/reportGenerator/view_csv/customSingleStationReport/daily/549:NV:SNTL%7Cid=%22%22%7Cname/2013-01-15,2013-01-18/SNWD::value
     # http://wcc.sc.egov.usda.gov/reportGenerator/view_csv/customSingleStationReport/daily/#{id}%7Cid%3D%22%22%7Cname/-#{days}%2C0/WTEQ%3A%3Avalue%2CWTEQ%3A%3Adelta%2CSNWD%3A%3Avalue%2CSNWD%3A%3Adelta
 
+    # Each parameter on the end adds a new data field to the report: 
+    # WTEQ::value (snow water equivalent)
+    # WTEQ::delta (change in snow water equivalent)
+    # SNWD::value (snow depth)
+    # SNWD::delta (change in snow depth)
+    # TOBS::value (observed air temperature)
 
     if start_date
       date = "#{start_date},#{end_date}"
@@ -109,7 +115,7 @@ class Snotel < Sinatra::Base
       date = "-#{days}"
     end
 
-    uri = URI("http://wcc.sc.egov.usda.gov/reportGenerator/view_csv/customSingleStationReport/daily/#{id}%7Cid%3D%22%22%7Cname/#{date}%2C0/WTEQ%3A%3Avalue%2CWTEQ%3A%3Adelta%2CSNWD%3A%3Avalue%2CSNWD%3A%3Adelta")
+    uri = URI("http://wcc.sc.egov.usda.gov/reportGenerator/view_csv/customSingleStationReport/daily/#{id}%7Cid%3D%22%22%7Cname/#{date}%2C0/WTEQ%3A%3Avalue%2CWTEQ%3A%3Adelta%2CSNWD%3A%3Avalue%2CSNWD%3A%3Adelta%2CTOBS%3A%3Avalue")
     json = Net::HTTP.get(uri)
     
     json_filtered = json.gsub(/(^#.+|#)/, '').gsub(/^\s+/, "") # remove comments at top of file


### PR DESCRIPTION
modify the URI request made to snotel to include TOBS::value - the
observed air temperature. This is returned in the json as

"Air Temperature Observed (degF)":"30"

I’m sending a matching pull request to update the docs in powderlines.
